### PR TITLE
Call _setup_logging earlier.

### DIFF
--- a/simp_le.py
+++ b/simp_le.py
@@ -767,10 +767,10 @@ def _main(cli_args):
     args = create_parser().parse_args(cli_args)
     if args.test:  # --test
         test(args)
-    elif args.vhosts is None:
+    _setup_logging(args.verbose)
+    if args.vhosts is None:
         raise Error('You must set at least one -d/--vhost')
 
-    _setup_logging(args.verbose)
     logger.debug('%r parsed as %r', cli_args, args)
 
     if not _persisted_plugins_cover_all_compoenents(args.ioplugins):


### PR DESCRIPTION
If this isn't done before the first attempt to use the logger, instead
of the logged text, the user will see:

```
No handlers could be found for logger "simp_le"
```

Previously, forgetting -d/--vhost would trigger the behavior.

Thanks for the tool, btw.
