### PR TITLE
Fix PEM regex, try to make it more readable

### DIFF
--- a/simp_le.py
+++ b/simp_le.py
@@ -84,13 +84,12 @@ class UnitTestCase(unittest.TestCase):
     """simp_le unit test case."""
 
 
-_PEM_RE_LABELCHAR = '[%s]' % ''.join(
-    [chr(x) for x in range(0x21, 0x7e) if x != 0x2c])
+_PEM_RE_LABELCHAR = r'[\x21-\x2c\x2e-\x7e]'
 _PEM_RE = re.compile(
     (r"""
-^-----BEGIN\ ((%(labelchar)s([- ]?%(labelchar)s)*)?)\s*-----$
+^-----BEGIN\ ((?:%s(?:[- ]?%s)*)?)\s*-----$
 .*?
-^-----END\ \1-----\s*""" % {'labelchar': _PEM_RE_LABELCHAR}).encode(),
+^-----END\ \1-----\s*""" % (_PEM_RE_LABELCHAR, _PEM_RE_LABELCHAR)).encode(),
     re.DOTALL | re.MULTILINE | re.VERBOSE)
 _PEMS_SEP = b'\n'
 


### PR DESCRIPTION
0x2c ("comma") should be 0x2d ("hypen-minus"). range(X, Y) results in a
sequence X..Y-1 (off-by-one). Fix both issues by using a regex class
following the "labelchar" definition from the RC.

Also replace "%(labelchar)s" by just "%s", the regex was hard to read
with all those extra parentheses. Use "(?:..)" instead of "(..)" when
grouping for repetition rather than backreferences.
