### PR TITLE
Allow empty files, do not fail on readonly files

### DIFF
--- a/simp_le.py
+++ b/simp_le.py
@@ -395,6 +395,13 @@ class FileIOPlugin(IOPlugin):
 
     def save_to_file(self, data):
         """Save data to file."""
+        try:
+            if self._read_file() == data:
+                logger.info('%s is unchanged')
+                return
+        except IOError as error:
+            logging.warning('Unable to read file before write: %s', e)
+
         logger.info('Saving %s', self.path)
         try:
             with open(self.path, self.WRITE_MODE) as persist_file:


### PR DESCRIPTION
The account key typically does not change. I have made it read-only
and now simp_le fails here... Read the contents first before writing.
