### PR TITLE
ensure boostrap.sh uses bash since it has bashisms

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/bash -xe
 
 # keep in sync with .travis.yml
 bootstrap_deb () {


### PR DESCRIPTION
Another fix would be to remove `"${installer?}"` and `command -v`...   But I find keeping scripts bashism-free to be a thankless task.  Easier to just give in.  :)
