### PR TITLE
Allow boostrap.sh to run without root

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,9 @@ Installation
     ./venv.sh
     export PATH=./venv/bin:$PATH
 
+`sudo` is optional.  If run as a regular user, `boostrap.sh` prints the
+commands for you to run as root.
+
 Help
 ----
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/sh -e
 
 run () {
   if [[ $EUID -ne 0 ]]; then

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 run () {
-  if [[ $EUID -ne 0 ]]; then
+  if [ "$(id -u)" -ne 0 ]; then
     if [ -z "$run_has_warned" ]; then
       echo 'Run these commands as root:'
       run_has_warned=1
@@ -10,7 +10,7 @@ run () {
 
   echo "$@"
 
-  if [[ $EUID -eq 0 ]]; then
+  if [ "$(id -u)" -eq 0 ]; then
     "$@"
   fi
 }

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,17 +1,32 @@
 #!/bin/sh -xe
 
+run () {
+  if [[ $EUID -ne 0 ]]; then
+    if [ -z "$run_has_warned" ]; then
+      echo 'Run these commands as root:'
+      run_has_warned=1
+    fi
+  fi
+
+  echo "$@"
+
+  if [[ $EUID -eq 0 ]]; then
+    "$@"
+  fi
+}
+
 # keep in sync with .travis.yml
 bootstrap_deb () {
-  apt-get update
+  run apt-get update
 
   # virtualenv binary can be found in different packages depending on
-  # distro version
+  # distro version (don't need root to run `apt-cache show`)
   virtualenv_bin_pkg="virtualenv"
   if ! apt-cache show -qq "${virtualenv_bin_pkg}" >/dev/null 2>&1; then
     virtualenv_bin_pkg="python-virtualenv"
   fi
 
-  apt-get install -y --no-install-recommends \
+  run apt-get install -y --no-install-recommends \
     ca-certificates \
     gcc \
     libssl-dev \
@@ -23,7 +38,7 @@ bootstrap_deb () {
 
 bootstrap_rpm () {
   installer=$(command -v dnf || command -v yum)
-  "${installer?}" install -y \
+  run "${installer?}" install -y \
     ca-certificates \
     gcc \
     libffi-devel \

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -39,4 +39,6 @@ then
 elif [ -f /etc/redhat-release ]
 then
   bootstrap_rpm
+else
+  echo "Don't know how to bootstrap your platform."
 fi


### PR DESCRIPTION
If run as root, bootstrap.sh runs the commands directly.  Otherwise, it prints the commands so you can run them yourself.

When I read hte README, I thought simp_le required root and almost passed it over.  This is my attempt to make things clearer.

It also makes bootstrap.sh print each command as it runs it and turns off `-x`.
