### PR TITLE
Travis hosts boulder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
   hosts:
     - le.wtf
     - le2.wtf
+    - boulder
     - boulder-mysql
     - boulder-rabbitmq
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ addons:
   hosts:
     - le.wtf
     - le2.wtf
+    - boulder-mysql
+    - boulder-rabbitmq
   apt:
     packages:
       # keep in sync with bootstrap.sh

--- a/simp_le.py
+++ b/simp_le.py
@@ -1464,8 +1464,8 @@ class IntegrationTests(unittest.TestCase):
     # this is a test suite | pylint: disable=missing-docstring
 
     SERVER = 'http://localhost:4000/directory'
-    TOS_SHA256 = ('3ae9d8149e59b8845069552fdae761c3'
-                  'a042fc5ede1fcdf8f37f7aa4707c4d6e')
+    TOS_SHA256 = ('b16e15764b8bc06c5c3f9f19bc8b99fa'
+                  '48e7894aa5a6ccdad65da49bbf564793')
     PORT = 5002
 
     @classmethod


### PR DESCRIPTION
Boulder seems to have some shiny new setup.

Unfortunately, Travis build breaks due to https://github.com/letsencrypt/boulder/issues/1720.
