### PR TITLE
CSR instead of cert key (fixes #13, #53)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@
 # ... as well as external IO plugin script
 /external.sh
 
-# `sshfs user@host:$ROOT public_html/` and `--default_root=public_html`
+# `sshfs user@host:$ROOT public_html/.well-known/acme-challenge` and
+# `simp_le ... public_html/.well-known/acme-challenge`
 /public_html/

--- a/README.rst
+++ b/README.rst
@@ -7,10 +7,10 @@ Simple `Let’s Encrypt`_ client.
 
 .. code:: shell
 
+    ./examples/generate_csr.sh example.com
     simp_le --email you@example.com -f account_key.json \
-      -f fullchain.pem -f key.pem \
-      -d example.com -d www.example.com --default_root /var/www/html \
-      -d example.net:/var/www/other_html
+      -f csr.pem -f fullchain.pem -f chain.pem -f cert.pem \
+      /var/www/html/.well-known/acme-challenge
 
 For more info see ``simp_le --help``.
 
@@ -22,9 +22,9 @@ Manifest
 2.  ``simp_le --valid_min ${seconds?} -f cert.pem`` implies that
     ``cert.pem`` is valid for at at least ``valid_min``. Register new
     ACME CA account if necessary. Issue new certificate if no previous
-    key/certificate/chain found. Renew only if necessary.
+    certificate/chain found. Renew only if necessary.
 
-3.  (Sophisticated) “manager” for
+3.  (Sophisticated) "manager" for
     ``${webroot?}/.well-known/acme-challenge`` only. No challenges other
     than ``http-01``. Existing web-server must be running already.
 
@@ -40,16 +40,16 @@ Manifest
     should write their own wrapper scripts or use shell aliases if
     necessary.
 
-8.  Support multiple domains with multiple roots. Always create single
+8.  Support multiple domains (sharing
+    ``${webroot?}/.well-known/acme-challenge``). Always create single
     SAN certificate per ``simp_le`` run.
 
-9.  Flexible storage capabilities. Built-in
-    ``simp_le -f fullchain.pem    -f key.pem``,
-    ``simp_le -f chain.pem -f cert.pem -f key.pem``, etc. Extensions
-    through ``simp_le -f external.sh``.
+9.  Flexible storage capabilities. Built-in ``simp_le -f
+    fullchain.pem``, ``simp_le -f chain.pem -f cert.pem``,
+    etc. Extensions through ``simp_le -f external.sh``.
 
-10. Do not allow specifying output file paths. Users should symlink if
-    necessary!
+10. Do not allow specifying input/output file paths. Users should
+    symlink if necessary!
 
 11. No need to allow specifying an arbitrary command when renewal has
     happened, just check the exit code:

--- a/examples/external.sh
+++ b/examples/external.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 # Dummy example external script that loads/saves
-# account_key/key/cert/chain to /tmp/foo; Usage: `simp_le -f
+# account_key/csr/cert/chain to /tmp/foo; Usage: `simp_le -f
 # external.sh`.
 
 load () {
@@ -13,7 +13,7 @@ save () {
 }
 
 persisted () {
-  echo account_key key cert chain
+  echo account_key csr cert chain
 }
 
 case $1 in

--- a/examples/generate_csr.sh
+++ b/examples/generate_csr.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+#
+# This script generates a simple SAN CSR to be used with ACME CA.
+
+if [ "$#" -lt 1 ]
+then
+  echo "Usage: $0 name [name...]" >&2
+  exit 1
+fi
+
+OUTFORM=${OUTFORM:-pem}
+OUT="csr.${OUTFORM}"
+# 512 or 1024 too low for Boulder, 2048 is smallest for tests
+BITS="${BITS:-4096}"
+KEYOUT=key.pem
+
+names="DNS:$1"
+shift
+for x in "$@"
+do
+  names="$names,DNS:$x"
+done
+
+openssl_cnf=$(mktemp)
+cat >"${openssl_cnf}" <<EOF
+[ req ]
+distinguished_name = req_distinguished_name
+[ req_distinguished_name ]
+[ san ]
+subjectAltName=\${ENV::SAN}
+EOF
+
+SAN="$names" openssl req -config "${openssl_cnf}" \
+  -new -nodes -subj '/' -reqexts san \
+  -out "${OUT}" \
+  -keyout "${KEYOUT}" \
+  -newkey rsa:"${BITS}" \
+  -outform "${OUTFORM}"
+
+rm "${openssl_cnf}"

--- a/simp_le.py
+++ b/simp_le.py
@@ -783,7 +783,7 @@ def create_parser():
         help='Directory URI for the CA ACME API endpoint.',
     )
 
-    parser.add_argument('root')
+    parser.add_argument('root', nargs='?', help='Path to webroot.')
     return parser
 
 
@@ -1194,6 +1194,8 @@ def main_with_exceptions(cli_args):
     elif args.version:  # --version
         sys.stdout.write('%s %s\n' % (os.path.basename(sys.argv[0]), VERSION))
         return EXIT_HELP_VERSION_OK
+    elif args.root is None:
+        raise Error('Webroot argument is required')
 
     setup_logging(args.verbose)
     logger.debug('%r parsed as %r', cli_args, args)

--- a/simp_le.py
+++ b/simp_le.py
@@ -514,7 +514,7 @@ class PluginIOTestMixin(object):
                 public_exponent=65537, key_size=1024,
                 backend=default_backend(),
             )),
-            csr=jose.ComparableX509(gen_csr(raw_key, ['example.com'])),
+            csr=jose.ComparableX509(gen_csr(raw_key, [b'example.com'])),
             cert=jose.ComparableX509(crypto_util.gen_ss_cert(raw_key, ['a'])),
             chain=[
                 jose.ComparableX509(crypto_util.gen_ss_cert(raw_key, ['b'])),

--- a/simp_le.py
+++ b/simp_le.py
@@ -1203,14 +1203,15 @@ def main_with_exceptions(cli_args):
     elif args.version:  # --version
         sys.stdout.write('%s %s\n' % (os.path.basename(sys.argv[0]), VERSION))
         return EXIT_HELP_VERSION_OK
-    elif args.root is None:
-        raise Error('Webroot argument is required')
 
     setup_logging(args.verbose)
     logger.debug('%r parsed as %r', cli_args, args)
 
     if args.revoke:  # --revoke
         return revoke(args)
+
+    if args.root is None:
+        raise Error('Webroot argument is required')
 
     check_plugins_persist_all(args.ioplugins)
 

--- a/simp_le.py
+++ b/simp_le.py
@@ -1369,7 +1369,7 @@ class IntegrationTests(unittest.TestCase):
             self._save_csr(b'le.wtf')
             self.assertEqual(EXIT_RENEWAL, self._run(args))
             initial_stats = self.get_stats(*files)
-            unchangeable_stats = self.get_stats(*files[:2])
+            unchangeable_stats = self.get_stats(files[0])
 
             self.assertEqual(EXIT_NO_RENEWAL, self._run(args))
             # No renewal => no files should be touched
@@ -1384,9 +1384,8 @@ class IntegrationTests(unittest.TestCase):
 
             # Changing SANs should trigger "renewal"
             self._save_csr(b'le.wtf', b'le2.wtf')
-            # but it shouldn't unnecessarily overwrite the account key
-            # or CSR (#67)
-            self.assertEqual(unchangeable_stats, self.get_stats(*files[:2]))
+            # but it shouldn't unnecessarily overwrite the account key (#67)
+            self.assertEqual(unchangeable_stats, self.get_stats(files[0]))
 
 
 if __name__ == '__main__':

--- a/simp_le.py
+++ b/simp_le.py
@@ -687,34 +687,6 @@ class CertFileTest(FileIOPluginTestMixin, UnitTestCase):
     PLUGIN_CLS = CertFile
 
 
-@IOPlugin.register(path='full.pem', typ=OpenSSL.crypto.FILETYPE_PEM)
-class FullFile(FileIOPlugin, OpenSSLIOPlugin):
-    """Private key, certificate and chain plugin."""
-
-    def persisted(self):
-        return self.Data(account_key=False, csr=True, cert=True, chain=True)
-
-    def load_from_content(self, content):
-        pems = split_pems(content)
-        return self.Data(
-            account_key=None,
-            csr=self.load_csr(next(pems)),
-            cert=self.load_cert(next(pems)),
-            chain=[self.load_cert(cert) for cert in pems],
-        )
-
-    def save(self, data):
-        pems = [self.dump_csr(data.csr), self.dump_cert(data.cert)]
-        pems.extend(self.dump_cert(cert) for cert in data.chain)
-        self.save_to_file(_PEMS_SEP.join(pems))
-
-
-class FullFileTest(FileIOPluginTestMixin, UnitTestCase):
-    """Tests for FullFile."""
-    # this is a test suite | pylint: disable=missing-docstring
-    PLUGIN_CLS = FullFile
-
-
 def create_parser():
     """Create argument parser."""
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
This PR substantially changes API for `simp_le` and will break existing customers
1. Instead of accepting `-f key.pem` (or `-f key.der`) it accepts `-f csr.pem` (`-f csr.der`) and expects the client to generate CSR (cf. `examples/generate_csr.sh`).
2. It reads domain names from the CSR instead of `-d`.
3. Only one webroot can be specified at a time (as a positional argument) instead of `--default_root` or `-d exmaple.com:root` syntax, so in case of multi-domain certificates customer is expected to arrange the file hierarchy (e.g. using symlinks).
4. Moreover, the webroot must now be specified including `.well-known/acme-challenge` (fixes #53).

It's not yet ready, but I hope to get it finished in O(week). Posting it here in advance, so that interested parties get an early notification about breaking changes.
