### PR TITLE
Don't call new_authz with a kwarg

### DIFF
--- a/simp_le.py
+++ b/simp_le.py
@@ -1283,7 +1283,7 @@ def persist_new_data(args, existing_data):
 
     authorizations = dict(
         (vhost.name, client.request_domain_challenges(
-            vhost.name, new_authzr_uri=client.directory.new_authz))
+            vhost.name, client.directory.new_authz))
         for vhost in args.vhosts
     )
     if any(supported_challb(auth) is None


### PR DESCRIPTION
This fixes the following issue:

```
Traceback (most recent call last):
  File "/simp_le-master/simp_le.py", line 1401, in main
    return main_with_exceptions(cli_args)
  File "/simp_le-master/simp_le.py", line 1386, in main_with_exceptions
    persist_new_data(args, existing_data)
  File "/simp_le-master/simp_le.py", line 1287, in persist_new_data
    for vhost in args.vhosts
  File "/simp_le-master/simp_le.py", line 1287, in <genexpr>
    for vhost in args.vhosts
TypeError: request_domain_challenges() got an unexpected keyword argument 'new_authzr_uri'
```
