### PR TITLE
Update README.rst with supported alternatives for simp_le

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,8 @@ This repository is not being actively maintained!
 
 See https://github.com/zenhack/simp_le for a more recently updated version of simp_le
 
+Or use `certbot` (the official Let’s Encrypt client) using the `certonly` mode which is quite compatible how simp_le works. You can migrate your account/configuration using `simp_le2certbot <https://github.com/meeuw/simp_le2certbot>`_.
+
 simp\_le
 ========
 

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,8 @@
+This repository is not being actively maintained!
+====
+
+See https://github.com/zenhack/simp_le for a more recently updated version of simp_le
+
 simp\_le
 ========
 


### PR DESCRIPTION
This PR extends #119 with a link to scripts to migrate your account/configuration to certbot. Certbot is the official Let’s Encrypt client which can be used in a `certonly` mode which is quite compatible with simp_le.

https://github.com/meeuw/simp_le2certbot